### PR TITLE
docs: polish README (Quickstart, API table, semantic demo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ and listing chunks.
 - `make test` — run pytest via uv
 - `make clean-db` — delete local Kùzu artifacts (WAL/DB)
 
+### 60-second flow
+
+```bash
+make run         # start the API (keep this running)
+make seed        # create Sample Doc with sections/chunks
+make chunks      # sanity check: expect count > 0
+make seed-emb    # write dummy one-hot embeddings (dev only)
+make semantic    # query nearest chunks via HNSW+cosine
+```
+
 ### Requirements
 - Python 3.11+
 - [uv](https://github.com/astral-sh/uv)
@@ -57,18 +67,21 @@ uv run pytest -q
 
 ## API
 
-| Method | Path                                           | Description |
-|-------:|------------------------------------------------|-------------|
-| GET    | `/health`                                      | Health check. |
-| POST   | `/seed?reset=true\|false`                      | Seed sample data (idempotent if `reset=false`). |
-| POST   | `/ingest`                                      | Create a document with sections/chunks. Returns 409 if title exists. |
-| GET    | `/chunks?doc=<title>&limit=<n>`                | List chunks (with optional doc filter). |
-| GET    | `/search?q=<text>&doc=<title>&limit=<n>&ci=bool` | **Substring search** in `Chunk.text`. `ci=true` (default) is **case-insensitive**; pass `ci=false` for case-sensitive. |
-| POST | `/search/semantic` — body: `{"vector":[...384 floats...], "k":5, "efs":200, "doc":"Title?"}` | Uses Kùzu’s `QUERY_VECTOR_INDEX` with HNSW (two hierarchical layers: upper sampled, lower full) and returns nearest chunks + distance. :contentReference[oaicite:3]{index=3} |
-| POST | `/debug/set_dummy_embeddings` | — writes simple one-hot vectors into `Chunk.embedding` so you can prove semantic search without external models. Then try:
-  - `make seed-emb`
-  - `make semantic`|
-| GET    | `/debug/indexes`                               | lists indexes via `CALL SHOW_INDEXES()`. Quick check locally: `make indexes` |
+| Method | Path | Description |
+|------:|------|-------------|
+| GET   | `/health` | Health check. |
+| POST  | `/seed?reset=true\|false` | Seed sample data (idempotent if `reset=false`). |
+| POST  | `/ingest` | Create a document with sections/chunks. Returns **409** if title exists. |
+| GET   | `/chunks?doc=<title>&limit=<n>` | List chunks (optionally filter by document). |
+| GET   | `/search?q=<text>&doc=<title>&limit=<n>&ci=<bool>` | **Substring search** in `Chunk.text`. `ci=true` (default) is case-insensitive. |
+| POST  | `/search/semantic` | **Vector search** via Kùzu HNSW. Body: `{"vector":[...384 floats...], "k":5, "efs":200, "doc":"Title?"}` |
+| POST  | `/debug/set_dummy_embeddings` | Dev helper: writes one-hot vectors into `Chunk.embedding` so semantic search works without an external model. |
+| GET   | `/debug/indexes` | Lists indexes via `CALL SHOW_INDEXES()`. |
+
+> **Tip:** If `/debug/set_dummy_embeddings` returns `{"updated": 0}`, you probably haven’t seeded yet. Run `make seed` (or `/ingest`) and try again.
+
+> **Tuning:** `/search/semantic` accepts `efs` (beam width). Higher `efs` ⇒ better recall, slower queries. Defaults are fine for the demo.
+
 
 
 ## Example calls
@@ -98,38 +111,21 @@ curl -s "http://127.0.0.1:8000/search?q=topic&doc=Kickoff%20Notes" | jq
 curl -s "http://127.0.0.1:8000/search?q=TOPIC&doc=Kickoff%20Notes&ci=false" | jq
 ```
 
-## Project structure (trimmed)
-
-```pgsql
-app/
-  api/
-    routes.py
-    schemas.py
-  core/
-    config.py
-    kuzu.py
-    tracing.py
-  graph/
-    schema.py
-    seed.py
-    search.py
-    repo.py
-    read.py
-var/
-  .gitkeep
-docs/
-tests
-  conftest.py
-  test_smoke.py
-
-```
-
 ## Notes
-- Row iteration with Kùzu: use ``` while res.has_next(): row = res.get_next()```.
+- Row iteration with Kùzu:
+  ```python
+  while res.has_next():
+      row = res.get_next()
+  ```
 
 - ```SERIAL``` IDs keep increasing across deletes—normal.
 
 - Reserved words: avoid ```order```; use ord (or backticks).
+
+### Why cosine + HNSW (in one paragraph)
+
+**Cosine** compares the *angle* between embedding vectors, which lines up well with “same meaning” in text embeddings (direction ≈ semantics). **HNSW** builds a multi-layer neighbor graph: a sparse **upper** layer for long jumps and a dense **lower** layer for local refinement. Queries do a greedy walk from top to bottom—fast and high-recall for nearest-neighbor search. For demos, the main knob is **`efs`** on `/search/semantic`: higher values look a bit harder and typically return better matches.
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
Refines README with:
- 60s Quickstart flow (make run → seed → chunks → seed-emb → semantic)
- Clean API table (semantic/debug clarified)
- Cosine+HNSW one-paragraph explainer
- Tips for dummy embeddings & efs tuning
