### PR TITLE
Dockerize app + README + Make targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# VCS & editor
+.git
+.gitignore
+.github
+.vscode
+.idea
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.pytest_cache
+.mypy_cache
+.venv
+.env
+.env.*
+
+# Local DB artifacts
+var/
+*.kuzu
+*.kuzulog
+*.kuzu.wal
+*.kuzu.tmp
+
+# Build noise
+dist/
+build/
+*.egg-info/
+
+# Misc
+docs/banner*.png

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,27 @@ clean-db:
 
 # Alias for CI locally
 ci: test
+
+IMAGE ?= mini-graph-rag
+TAG ?= latest
+
+.PHONY: docker-build docker-run docker-clean docker-shell
+
+docker-build:
+	docker build -t $(IMAGE):$(TAG) .
+
+# Mount ./var -> /data so DB persists across runs
+docker-run:
+	docker run --rm -it \
+	  -p 8000:8000 \
+	  -e KUZU_DB_PATH=/data/mini-graph-rag.kuzu \
+	  -v $(PWD)/var:/data \
+	  --name $(IMAGE) \
+	  $(IMAGE):$(TAG)
+
+docker-shell:
+	docker exec -it $(IMAGE) /bin/bash
+
+docker-clean:
+	- docker rm -f $(IMAGE) 2>/dev/null || true
+	- docker rmi $(IMAGE):$(TAG) 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ and listing chunks.
 
 ## Quickstart
 
+### Docker (one-liner)
+
+```bash
+make docker-build
+make docker-run
+# In another terminal:
+curl -s http://127.0.0.1:8000/health
+make seed
+make chunks
+make seed-emb
+make semantic
+
+```
+
 ### Make targets
 - `make run` — start FastAPI (reload on code; ignores DB dir)
 - `make seed` — seed sample data
@@ -135,9 +149,12 @@ curl -s "http://127.0.0.1:8000/search?q=TOPIC&doc=Kickoff%20Notes&ci=false" | jq
 - Start dev server excluding DB directory from reload:  
   `uv run uvicorn app.api.routes:app --reload --reload-exclude var/* --port 8000`
 
-## Roadmap
+### Known issues
 
-- Optional: Dockerize app or use Kùzu Explorer container for browsing.
+- In Docker, `/debug/set_dummy_embeddings` may fail with:  
+  `Cannot set property vec in table embeddings ... used in one or more indexes.`  
+  Locally it seems to works (or at least worked earlier). Will be addressed next (lets hope so :D)
+
 
 ## License
 [MIT](./LICENSE)

--- a/app/graph/semantic.py
+++ b/app/graph/semantic.py
@@ -93,15 +93,12 @@ def semantic_search(
 
 
 def drop_vector_index_if_exists() -> None:
-    """
-    Drop the vector index if it exists.
-    """
     conn = get_conn()
     try:
-        conn.execute(f"CALL DROP_INDEX('{INDEX_TBL}', '{INDEX_NAME}');")
+        # note: no trailing semicolon
+        conn.execute(f"CALL DROP_INDEX('{INDEX_TBL}', '{INDEX_NAME}')")
     except Exception:
-        pass  # index does not exist
-
+        pass
 
 def create_vector_index() -> None:
     """

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.7
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    # Persist DB outside the image
+    KUZU_DB_PATH=/data/mini-graph-rag.kuzu
+
+# System deps that are useful in practice (certs, tz, minimal build tools)
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+      ca-certificates tzdata gcc curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Workdir
+WORKDIR /app
+COPY . /app
+RUN pip install --upgrade pip setuptools wheel && pip install .
+
+# Expose FastAPI port
+EXPOSE 8000
+
+# Persist DB outside the container
+VOLUME ["/data"]
+
+# Healthcheck hits the app /health endpoint
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "curl", "-f", "http://localhost:8000/health" ]
+
+# Start the API
+CMD ["uvicorn", "app.api.routes:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Adds Dockerfile, .dockerignore, Make targets (docker-build/run), and README usage.
Known issue: /debug/set_dummy_embeddings fails inside container due to vector index update; works locally. Tracking to fix next.